### PR TITLE
Filetype 'handlebars' treated as 'html'.

### DIFF
--- a/main.js
+++ b/main.js
@@ -208,6 +208,7 @@ define(function (require, exports, module) {
         case 'php':
         case 'xml':
         case 'ejs':
+        case 'handlebars':
             formattedText = _formatHTML(unformattedText, indentChar, indentSize);
             batchUpdate(formattedText, isSelection);
             break;


### PR DESCRIPTION
The filetype 'handlebars' is added from the extension "Handlebars Syntax Highlighter (https://github.com/karl-sjogren/brackets-handlebars-templates).