### PR TITLE
disable php beatify on auto save

### DIFF
--- a/main.js
+++ b/main.js
@@ -197,8 +197,11 @@ define(function (require, exports, module) {
             formattedText = _formatJavascript(unformattedText, indentChar, indentSize);
             batchUpdate(formattedText, isSelection);
             break;
-        case 'html':
         case 'php':
+            if (autoSave) {
+                break;
+            }
+        case 'html':
         case 'xml':
         case 'ejs':
             formattedText = _formatHTML(unformattedText, indentChar, indentSize);


### PR DESCRIPTION
since it does break embedded php, it would be nice to disable it on auto save, and keep it in for manual selected code, so it only beautifies when you really intend to